### PR TITLE
fix!: Require explicit Disable PR creation

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -67,11 +67,11 @@ func (c *SCMClient) UpdateFile(ctx context.Context, repo, branch, path, message,
 		Signature: signature,
 	}
 	r, err := c.scmClient.Contents.Update(ctx, repo, path, &params)
+	if r != nil && isErrorStatus(r.Status) {
+		return SCMError{Msg: fmt.Sprintf("failed to update file %s in repo %s branch %s", path, repo, branch), Status: r.Status}
+	}
 	if err != nil {
 		return err
-	}
-	if isErrorStatus(r.Status) {
-		return SCMError{Msg: fmt.Sprintf("failed to update file %s in repo %s branch %s", path, repo, branch), Status: r.Status}
 	}
 	return nil
 }
@@ -90,11 +90,11 @@ func (c *SCMClient) DeleteFile(ctx context.Context, repo, branch, path, message,
 		Signature: signature,
 	}
 	r, err := c.scmClient.Contents.Delete(ctx, repo, path, &params)
+	if r != nil && isErrorStatus(r.Status) {
+		return SCMError{Msg: fmt.Sprintf("failed to delete file %s in repo %s branch %s", path, repo, branch), Status: r.Status}
+	}
 	if err != nil {
 		return err
-	}
-	if isErrorStatus(r.Status) {
-		return SCMError{Msg: fmt.Sprintf("failed to delete file %s in repo %s branch %s", path, repo, branch), Status: r.Status}
 	}
 	return nil
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -211,6 +211,29 @@ func TestUpdateFileWithNoConnection(t *testing.T) {
 	}
 }
 
+func TestUpdateFileToPrivateRepositoryWithBadCreds(t *testing.T) {
+	message := "just a test message"
+	branch := "master"
+	repository := "Codertocat/Hello-World"
+	signature := scm.Signature{
+		Name:  "John Doe",
+		Email: "john.doe@example.com",
+	}
+
+	scmClient, err := factory.NewClient("github", "", "myfaketoken")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := New(scmClient)
+
+	err = client.UpdateFile(context.TODO(), repository, branch,
+		"./README.md", message, "6113728f27ae82c7b1a177c8d03f9e96e0adf246",
+		signature, []byte(`testing`))
+	if !test.MatchError(t, `failed to update file.*\(401\)$`, err) {
+		t.Fatalf("failed to match error: %s", err)
+	}
+}
+
 func TestCreateBranchInGitHub(t *testing.T) {
 	sha := "aa218f56b14c9653891f9e74264a383fa43fefbd"
 


### PR DESCRIPTION
This breaks the older flow where a PR would be disabled
if a new branch prefix was empty.

Also:
* Ensure we get a sha for update ops
* Better handling of notFound errors